### PR TITLE
Fix for leaked GL_DEPTH_TEST and GL_BLEND OpenGL state

### DIFF
--- a/src/render/View3D.cpp
+++ b/src/render/View3D.cpp
@@ -740,6 +740,9 @@ void View3D::drawOutlines() const
         // do NOT release shader, this is no longer supported in OpenGL 3.2
         glBindVertexArray(0);
     }
+
+    glEnable(GL_DEPTH_TEST);
+    glDisable(GL_BLEND);
 }
 
 /// Draw the 3D cursor


### PR DESCRIPTION
Otherwise the bounding box is being drawn over the point cloud, even when it is further away.