### PR TITLE
Build displaz without GL/glu.h compile-time dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if (DISPLAZ_USE_LAS)
 endif()
 
 if (DISPLAZ_EMBED_GLEW)
-    add_definitions(-DGLEW_STATIC)
+    add_definitions(-DGLEW_STATIC -DGLEW_NO_GLU)
     set(GLEW_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/thirdparty/glew)
     include_directories(BEFORE ${GLEW_INCLUDE_DIR})
     add_library(embeddedGLEW STATIC thirdparty/glew/glew.c)


### PR DESCRIPTION
GLEW has a historical and extraneous dependency on GL/glu.h

We can opt out for the purpose of targeting flatpak builds:
https://flatpak.org/