### PR TITLE
Docker builds of displaz for Ubuntu and Debian

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+# Docker builds of displaz
+
+## Motivation
+
+Check the displaz builds and tests for a variety of Linux flavours.
+
+## User Guide
+
+1. `docker build docker/ubuntu_18_04`
+2. `docker image prune -af`
+
+## Options
+
+* REPO build from specified from git repository
+* MIRROR use Ubuntu package mirror
+  * Australia: `http://au.archive.ubuntu.com/ubuntu/`
+
+For example:
+
+`docker build docker/ubuntu_18_04 --build-arg MIRROR=http://au.archive.ubuntu.com/ubuntu/ `
+
+## Notes
+
+* Ubuntu 12.04 Precise does not support C++11 required for displaz

--- a/docker/debian_buster/Dockerfile
+++ b/docker/debian_buster/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir ${SCRATCH}
 WORKDIR ${SCRATCH}
 
 ARG REPO
-ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+ENV REPO ${REPO:-https://github.com/FugroRoames/displaz.git}
 RUN git clone ${REPO} repo
 
 #

--- a/docker/debian_buster/Dockerfile
+++ b/docker/debian_buster/Dockerfile
@@ -1,4 +1,4 @@
-# Minimal mapbox/protozero build, test and install
+# Minimal displaz Qt5 build, test and install
 # using Docker Debian 10 (buster)
 
 FROM debian:buster

--- a/docker/debian_buster/Dockerfile
+++ b/docker/debian_buster/Dockerfile
@@ -1,0 +1,56 @@
+# Minimal mapbox/protozero build, test and install
+# using Docker Debian 10 (buster)
+
+FROM debian:buster
+MAINTAINER Nigel Stewart (nigels@nigels.com)
+
+#
+# Update and install build tools, dependencies
+#
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update
+RUN apt dist-upgrade -y
+
+RUN apt install -y build-essential git cmake doxygen graphviz cppcheck
+RUN apt install -y g++ cmake qt5-default python-docutils
+
+#
+# Clone repo
+#
+
+ENV SCRATCH /scratch
+RUN mkdir ${SCRATCH}
+WORKDIR ${SCRATCH}
+
+ARG REPO
+ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+RUN git clone ${REPO} repo
+
+#
+# Build
+#
+
+RUN mkdir -p ${SCRATCH}/repo/build_external
+WORKDIR ${SCRATCH}/repo/build_external
+RUN cmake ../thirdparty/external
+RUN make
+
+RUN mkdir -p ${SCRATCH}/repo/build
+WORKDIR ${SCRATCH}/repo/build
+RUN cmake ..
+RUN make
+
+#
+# Test
+#
+
+RUN ctest
+
+#
+# Install
+#
+
+RUN make install
+RUN find /usr/local

--- a/docker/debian_stretch/Dockerfile
+++ b/docker/debian_stretch/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir ${SCRATCH}
 WORKDIR ${SCRATCH}
 
 ARG REPO
-ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+ENV REPO ${REPO:-https://github.com/FugroRoames/displaz.git}
 RUN git clone ${REPO} repo
 
 #

--- a/docker/debian_stretch/Dockerfile
+++ b/docker/debian_stretch/Dockerfile
@@ -1,0 +1,56 @@
+# Minimal mapbox/protozero build, test and install
+# using Docker Debian 9 (stretch)
+
+FROM debian:stretch
+MAINTAINER Nigel Stewart (nigels@nigels.com)
+
+#
+# Update and install build tools, dependencies
+#
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update
+RUN apt dist-upgrade -y
+
+RUN apt install -y build-essential git cmake doxygen graphviz cppcheck
+RUN apt install -y g++ cmake qt5-default python-docutils
+
+#
+# Clone repo
+#
+
+ENV SCRATCH /scratch
+RUN mkdir ${SCRATCH}
+WORKDIR ${SCRATCH}
+
+ARG REPO
+ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+RUN git clone ${REPO} repo
+
+#
+# Build
+#
+
+RUN mkdir -p ${SCRATCH}/repo/build_external
+WORKDIR ${SCRATCH}/repo/build_external
+RUN cmake ../thirdparty/external
+RUN make
+
+RUN mkdir -p ${SCRATCH}/repo/build
+WORKDIR ${SCRATCH}/repo/build
+RUN cmake ..
+RUN make
+
+#
+# Test
+#
+
+RUN ctest
+
+#
+# Install
+#
+
+RUN make install
+RUN find /usr/local

--- a/docker/debian_stretch/Dockerfile
+++ b/docker/debian_stretch/Dockerfile
@@ -1,4 +1,4 @@
-# Minimal mapbox/protozero build, test and install
+# Minimal displaz Qt5 build, test and install
 # using Docker Debian 9 (stretch)
 
 FROM debian:stretch

--- a/docker/ubuntu_14_04/Dockerfile
+++ b/docker/ubuntu_14_04/Dockerfile
@@ -1,4 +1,4 @@
-# Minimal mapbox/protozero build, test and install
+# Minimal displaz Qt5 build, test and install
 # using Docker Ubuntu 14.04 (Trusty)
 
 FROM ubuntu:trusty

--- a/docker/ubuntu_14_04/Dockerfile
+++ b/docker/ubuntu_14_04/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir ${SCRATCH}
 WORKDIR ${SCRATCH}
 
 ARG REPO
-ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+ENV REPO ${REPO:-https://github.com/FugroRoames/displaz.git}
 RUN git clone ${REPO} repo
 
 #

--- a/docker/ubuntu_14_04/Dockerfile
+++ b/docker/ubuntu_14_04/Dockerfile
@@ -1,0 +1,71 @@
+# Minimal mapbox/protozero build, test and install
+# using Docker Ubuntu 14.04 (Trusty)
+
+FROM ubuntu:trusty
+MAINTAINER Nigel Stewart (nigels@nigels.com)
+
+#
+# Optional custom package mirror
+#
+# --build-arg MIRROR=http://au.archive.ubuntu.com/ubuntu/
+#
+
+ARG MIRROR
+ENV MIRROR ${MIRROR:-http://archive.ubuntu.com/ubuntu}
+
+RUN sed -i -r "/#.*/d"                                           /etc/apt/sources.list
+RUN sed -i -r "/^$/d"                                            /etc/apt/sources.list
+RUN cat /etc/apt/sources.list
+RUN sed -i -r "s#deb .* trusty(-.*)? #deb ${MIRROR} trusty\\1 #" /etc/apt/sources.list
+RUN cat /etc/apt/sources.list
+
+#
+# Update and install build tools, dependencies
+#
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update
+RUN apt dist-upgrade -y
+
+RUN apt install -y build-essential git cmake doxygen graphviz cppcheck
+RUN apt install -y g++ cmake qt5-default python-docutils
+
+#
+# Clone repo
+#
+
+ENV SCRATCH /scratch
+RUN mkdir ${SCRATCH}
+WORKDIR ${SCRATCH}
+
+ARG REPO
+ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+RUN git clone ${REPO} repo
+
+#
+# Build
+#
+
+RUN mkdir -p ${SCRATCH}/repo/build_external
+WORKDIR ${SCRATCH}/repo/build_external
+RUN cmake ../thirdparty/external
+RUN make
+
+RUN mkdir -p ${SCRATCH}/repo/build
+WORKDIR ${SCRATCH}/repo/build
+RUN cmake ..
+RUN make
+
+#
+# Test
+#
+
+RUN ctest
+
+#
+# Install
+#
+
+RUN make install
+RUN find /usr/local

--- a/docker/ubuntu_16_04/Dockerfile
+++ b/docker/ubuntu_16_04/Dockerfile
@@ -1,4 +1,4 @@
-# Minimal mapbox/protozero build, test and install
+# Minimal displaz Qt5 build, test and install
 # using Docker Ubuntu 16.04 (Xenial)
 
 FROM ubuntu:xenial

--- a/docker/ubuntu_16_04/Dockerfile
+++ b/docker/ubuntu_16_04/Dockerfile
@@ -1,0 +1,71 @@
+# Minimal mapbox/protozero build, test and install
+# using Docker Ubuntu 16.04 (Xenial)
+
+FROM ubuntu:xenial
+MAINTAINER Nigel Stewart (nigels@nigels.com)
+
+#
+# Optional custom package mirror
+#
+# --build-arg MIRROR=http://au.archive.ubuntu.com/ubuntu/
+#
+
+ARG MIRROR
+ENV MIRROR ${MIRROR:-http://archive.ubuntu.com/ubuntu}
+
+RUN sed -i -r "/#.*/d"                                           /etc/apt/sources.list
+RUN sed -i -r "/^$/d"                                            /etc/apt/sources.list
+RUN cat /etc/apt/sources.list
+RUN sed -i -r "s#deb .* xenial(-.*)? #deb ${MIRROR} xenial\\1 #" /etc/apt/sources.list
+RUN cat /etc/apt/sources.list
+
+#
+# Update and install build tools, dependencies
+#
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update
+RUN apt dist-upgrade -y
+
+RUN apt install -y build-essential git cmake doxygen graphviz cppcheck
+RUN apt install -y g++ cmake qt5-default python-docutils
+
+#
+# Clone repo
+#
+
+ENV SCRATCH /scratch
+RUN mkdir ${SCRATCH}
+WORKDIR ${SCRATCH}
+
+ARG REPO
+ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+RUN git clone ${REPO} repo
+
+#
+# Build
+#
+
+RUN mkdir -p ${SCRATCH}/repo/build_external
+WORKDIR ${SCRATCH}/repo/build_external
+RUN cmake ../thirdparty/external
+RUN make
+
+RUN mkdir -p ${SCRATCH}/repo/build
+WORKDIR ${SCRATCH}/repo/build
+RUN cmake ..
+RUN make
+
+#
+# Test
+#
+
+RUN ctest
+
+#
+# Install
+#
+
+RUN make install
+RUN find /usr/local

--- a/docker/ubuntu_16_04/Dockerfile
+++ b/docker/ubuntu_16_04/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir ${SCRATCH}
 WORKDIR ${SCRATCH}
 
 ARG REPO
-ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+ENV REPO ${REPO:-https://github.com/FugroRoames/displaz.git}
 RUN git clone ${REPO} repo
 
 #

--- a/docker/ubuntu_18_04/Dockerfile
+++ b/docker/ubuntu_18_04/Dockerfile
@@ -40,7 +40,7 @@ RUN mkdir ${SCRATCH}
 WORKDIR ${SCRATCH}
 
 ARG REPO
-ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+ENV REPO ${REPO:-https://github.com/FugroRoames/displaz.git}
 RUN git clone ${REPO} repo
 
 #

--- a/docker/ubuntu_18_04/Dockerfile
+++ b/docker/ubuntu_18_04/Dockerfile
@@ -1,4 +1,4 @@
-# Minimal mapbox/protozero build, test and install
+# Minimal displaz Qt5 build, test and install
 # using Docker Ubuntu 18.04 (Bionic)
 
 FROM ubuntu:bionic

--- a/docker/ubuntu_18_04/Dockerfile
+++ b/docker/ubuntu_18_04/Dockerfile
@@ -1,0 +1,71 @@
+# Minimal mapbox/protozero build, test and install
+# using Docker Ubuntu 18.04 (Bionic)
+
+FROM ubuntu:bionic
+MAINTAINER Nigel Stewart (nigels@nigels.com)
+
+#
+# Optional custom package mirror
+#
+# --build-arg MIRROR=http://au.archive.ubuntu.com/ubuntu/
+#
+
+ARG MIRROR
+ENV MIRROR ${MIRROR:-http://archive.ubuntu.com/ubuntu}
+
+RUN sed -i -r "/#.*/d"                                           /etc/apt/sources.list
+RUN sed -i -r "/^$/d"                                            /etc/apt/sources.list
+RUN cat /etc/apt/sources.list
+RUN sed -i -r "s#deb .* bionic(-.*)? #deb ${MIRROR} bionic\\1 #" /etc/apt/sources.list
+RUN cat /etc/apt/sources.list
+
+#
+# Update and install build tools, dependencies
+#
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update
+RUN apt dist-upgrade -y
+
+RUN apt install -y build-essential git cmake doxygen graphviz cppcheck
+RUN apt install -y g++ cmake qt5-default python-docutils
+
+#
+# Clone repo
+#
+
+ENV SCRATCH /scratch
+RUN mkdir ${SCRATCH}
+WORKDIR ${SCRATCH}
+
+ARG REPO
+ENV REPO ${REPO:-https://github.com/c42f/displaz.git}
+RUN git clone ${REPO} repo
+
+#
+# Build
+#
+
+RUN mkdir -p ${SCRATCH}/repo/build_external
+WORKDIR ${SCRATCH}/repo/build_external
+RUN cmake ../thirdparty/external
+RUN make
+
+RUN mkdir -p ${SCRATCH}/repo/build
+WORKDIR ${SCRATCH}/repo/build
+RUN cmake ..
+RUN make
+
+#
+# Test
+#
+
+RUN ctest
+
+#
+# Install
+#
+
+RUN make install
+RUN find /usr/local


### PR DESCRIPTION
The Debian Buster build fails with an error.

```
[ 14%] Building CXX object src/CMakeFiles/unit_tests.dir/test_main.cpp.o
[ 15%] Linking CXX executable ../bin/unit_tests
[ 15%] Built target unit_tests
[ 16%] Generating qrc_resource.cpp
RCC: Error in '/scratch/repo/src/resource.qrc': Cannot find file 'resource/axes.png'
make[2]: *** [src/CMakeFiles/displaz.dir/build.make:143: src/qrc_resource.cpp] Error 1
make[1]: *** [CMakeFiles/Makefile2:205: src/CMakeFiles/displaz.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
The command '/bin/sh -c make' returned a non-zero code: 2
```

The others succeed.

