### PR TITLE
Fixup for showing LAS.Colour

### DIFF
--- a/src/las_io.cpp
+++ b/src/las_io.cpp
@@ -130,7 +130,7 @@ bool PointArray::loadLas(QString fileName, size_t maxPointCount,
     uint16_t* color = 0;
     if (hasColor)
     {
-        fields.push_back(GeomField(TypeSpec(TypeSpec::Uint,2,3,TypeSpec::Color),
+        fields.push_back(GeomField(TypeSpec(TypeSpec::Uint,2,3,TypeSpec::Color,true),
                                         "color", npoints));
         color = fields.back().as<uint16_t>();
     }

--- a/src/render/PointArray.cpp
+++ b/src/render/PointArray.cpp
@@ -775,7 +775,7 @@ DrawCount PointArray::drawPoints(QGLShaderProgram& prog, const TransformState& t
                 GLintptr arrayElementOffset = bufferOffset + j*field.spec.elsize;
 
                 if ((attr->baseType == TypeSpec::Int || attr->baseType == TypeSpec::Uint) &&
-                    !field.spec.fixedPoint)
+                    field.spec.fixedPoint)
                 {
                     glVertexAttribIPointer(attr->location, vecSize, glBaseType(field.spec),
                                            0, (const GLvoid *)arrayElementOffset);

--- a/src/typespec.h
+++ b/src/typespec.h
@@ -51,10 +51,10 @@ struct TypeSpec
     bool fixedPoint; /// For Int,Uint: indicates fixed point scaling by
                      /// max value of the underlying integer type
 
-    TypeSpec() : type(Unknown), elsize(0), count(0), semantics(Array), fixedPoint(false) {}
+    TypeSpec() : type(Unknown), elsize(0), count(0), semantics(Array), fixedPoint(true) {}
 
     TypeSpec(Type type, int elsize, int count = 1,
-             Semantics semantics = Array, bool fixedPoint = false)
+             Semantics semantics = Array, bool fixedPoint = true)
         : type(type),
         elsize(elsize),
         count(count),


### PR DESCRIPTION
Seems like commit dffba11a29ac10f461d3b2d37b7a8027fd69c3c9 by @JoshChristie broke the display of LAS colour (uint16_t).  This change fixes the problem.