### PR TITLE
cmake install support for FlatPak purpose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ install(DIRECTORY thirdparty/licenses/ DESTINATION "${DISPLAZ_DOC_DIR}/thirdpart
 
 if(UNIX AND NOT APPLE)
     SET(DDM_PIXMAPS_DIR "share/icons")
-    SET(DDM_DESKTOP_DIR "usr/share/applications")
+    SET(DDM_DESKTOP_DIR "share/applications")
 
     install(FILES src/resource/icons/hicolor/256x256/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/256x256/apps/")
     install(FILES src/resource/icons/hicolor/128x128/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/128x128/apps/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ if (WIN32)
     cmake_policy(SET CMP0020 NEW)
 endif()
 
+# For flatpak purposes a full ID is required for DISPLAZ_ID
+# Such as: com.fugro.roames.displaz
+set(DISPLAZ_ID "displaz" CACHE STRING "ID for displaz" )
+
 option(DISPLAZ_STATIC "Build against static libraries" FALSE)
 option(DISPLAZ_USE_LAS "Build with support for reading las files" TRUE)
 option(DISPLAZ_USE_PDAL "Use PDAL for reading las files" FALSE)
@@ -159,14 +163,13 @@ if(UNIX AND NOT APPLE)
     SET(DDM_PIXMAPS_DIR "share/icons")
     SET(DDM_DESKTOP_DIR "share/applications")
 
-    install(FILES src/resource/icons/hicolor/256x256/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/256x256/apps/")
-    install(FILES src/resource/icons/hicolor/128x128/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/128x128/apps/")
-    install(FILES src/resource/icons/hicolor/32x32/apps/displaz.png    DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/32x32/apps/")
-    install(FILES src/resource/icons/hicolor/16x16/apps/displaz.png    DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/16x16/apps/")
-    install(FILES src/resource/icons/hicolor/scalable/apps/displaz.svg DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/scalable/apps/")
-    install(FILES src/resource/icons/hicolor/scalable/apps/displaz.svg DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/scalable/apps/")
+    install(FILES src/resource/icons/hicolor/256x256/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/256x256/apps/"  RENAME "${DISPLAZ_ID}.png")
+    install(FILES src/resource/icons/hicolor/128x128/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/128x128/apps/"  RENAME "${DISPLAZ_ID}.png")
+    install(FILES src/resource/icons/hicolor/32x32/apps/displaz.png    DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/32x32/apps/"    RENAME "${DISPLAZ_ID}.png")
+    install(FILES src/resource/icons/hicolor/16x16/apps/displaz.png    DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/16x16/apps/"    RENAME "${DISPLAZ_ID}.png")
+    install(FILES src/resource/icons/hicolor/scalable/apps/displaz.svg DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/scalable/apps/" RENAME "${DISPLAZ_ID}.svg")
 
-    install(FILES src/resource/applications/displaz.desktop            DESTINATION "${DDM_DESKTOP_DIR}/")
+    install(FILES src/resource/applications/displaz.desktop            DESTINATION "${DDM_DESKTOP_DIR}/" RENAME "${DISPLAZ_ID}.desktop")
 endif()
 
 #------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ include_directories(${ILMBASE_INCLUDE_DIRS})
 
 #------------------------------------------------------------------------------
 # Install directory for binaries
-# (It would seem sensible to avoid a bin directory on windows, but in practise
+# (It would seem sensible to avoid a bin directory on windows, but in practice
 # the NSIS installer expects binaries to be there.)
 set(DISPLAZ_BIN_DIR "bin")
 if (WIN32)
@@ -155,6 +155,19 @@ install(DIRECTORY test/ DESTINATION "${DISPLAZ_DOC_DIR}/examples")
 install(DIRECTORY shaders/ DESTINATION "${DISPLAZ_SHADER_DIR}")
 install(DIRECTORY thirdparty/licenses/ DESTINATION "${DISPLAZ_DOC_DIR}/thirdparty_licenses")
 
+if(UNIX AND NOT APPLE)
+    SET(DDM_PIXMAPS_DIR "share/icons")
+    SET(DDM_DESKTOP_DIR "usr/share/applications")
+
+    install(FILES src/resource/icons/hicolor/256x256/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/256x256/apps/")
+    install(FILES src/resource/icons/hicolor/128x128/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/128x128/apps/")
+    install(FILES src/resource/icons/hicolor/32x32/apps/displaz.png    DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/32x32/apps/")
+    install(FILES src/resource/icons/hicolor/16x16/apps/displaz.png    DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/16x16/apps/")
+    install(FILES src/resource/icons/hicolor/scalable/apps/displaz.svg DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/scalable/apps/")
+    install(FILES src/resource/icons/hicolor/scalable/apps/displaz.svg DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/scalable/apps/")
+
+    install(FILES src/resource/applications/displaz.desktop            DESTINATION "${DDM_DESKTOP_DIR}/")
+endif()
 
 #------------------------------------------------------------------------------
 # Documentation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ install(DIRECTORY thirdparty/licenses/ DESTINATION "${DISPLAZ_DOC_DIR}/thirdpart
 if(UNIX AND NOT APPLE)
     SET(DDM_PIXMAPS_DIR "share/icons")
     SET(DDM_DESKTOP_DIR "share/applications")
+    SET(DDM_METADATA_DIR "share/metadata")
 
     install(FILES src/resource/icons/hicolor/256x256/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/256x256/apps/"  RENAME "${DISPLAZ_ID}.png")
     install(FILES src/resource/icons/hicolor/128x128/apps/displaz.png  DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/128x128/apps/"  RENAME "${DISPLAZ_ID}.png")
@@ -170,6 +171,8 @@ if(UNIX AND NOT APPLE)
     install(FILES src/resource/icons/hicolor/scalable/apps/displaz.svg DESTINATION "${DDM_PIXMAPS_DIR}/hicolor/scalable/apps/" RENAME "${DISPLAZ_ID}.svg")
 
     install(FILES src/resource/applications/displaz.desktop            DESTINATION "${DDM_DESKTOP_DIR}/" RENAME "${DISPLAZ_ID}.desktop")
+
+    install(FILES src/resource/metainfo/displaz.appdata.xml            DESTINATION "${DDM_METADATA_DIR}/" RENAME "${DISPLAZ_ID}.appdata.xml")
 endif()
 
 #------------------------------------------------------------------------------

--- a/src/resource/applications/displaz.desktop
+++ b/src/resource/applications/displaz.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=displaz
+Exec=displaz
+Type=Application
+Icon=displaz
+Categories=Qt;Education;Science;Geography;
+Keywords=point cloud;LIDAR;viewer

--- a/src/resource/metainfo/displaz.appdata.xml
+++ b/src/resource/metainfo/displaz.appdata.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+	<id>com.fugro.roames.displaz</id>
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>BSD-3-Clause</project_license>
+	<name>displaz</name>
+	<launchable type="desktop-id">com.fugro.roames.displaz.desktop</launchable>
+	<summary>A hackable LIDAR viewer</summary>
+	<description>
+		<p>
+			displaz is a cross platform viewer for displaying LIDAR point clouds and derived artifacts such as fitted meshes. The interface was originally developed for viewing large airborne laser scans, but also works quite well for point clouds acquired using terrestrial lidar and other sources such as bathymetric sonar.
+		</p>
+		<p>
+			The goal is to provide a flexible and programmable technical tool for exploring large lidar point data sets and derived geometry.
+		</p>
+		<ul>
+			<li>Open point clouds up to the size of main memory. Performance remains interactive as the number of points becomes too large to draw in a single frame.</li>
+			<li>Create custom point visualizations. The OpenGL shader can be edited interactively. In the shader program, you automatically have access to any per-point attributes defined in the input file. Shader parameters are connected to user-defined GUI controls.</li>
+			<li>Plot interactively from your favourite programming language. Displaz IPC lets you script the interface from the command line. Experimental language bindings are available for C++, python, julia and Matlab.</li>
+		</ul>
+	</description>
+	<content_rating type="oars-1.1" />
+	<screenshots>
+		<screenshot type="default">
+			<image type="source">https://raw.githubusercontent.com/nigels-com/displaz/931c85cd94ecd9466ad29319252ddad67fde81e9/flatpak/screenshot/displaz-screenshot-2.jpg</image>
+		</screenshot>
+	</screenshots>
+	<url type="homepage">https://github.com/FugroRoames/displaz</url>
+	<releases>
+		<release version="0.4.1" date="2018-12-28" />
+		<release version="0.4.0" date="2017-05-07" />
+		<release version="0.3.2" date="2015-08-11" />
+	</releases>
+	<update_contact>nigels@nigels.com</update_contact>
+</component>


### PR DESCRIPTION
I think this is the minimal set of changes necessary for a Flatpak build of displaz from the FugroRoames/displaz repo.

- Add a DISPLAZ_ID cmake variable for opting-in to a full name such as `com.fugro.roames.displaz`
- Install the PNG and SVG icons, .desktop launcher file and metainfo application information

See also:
https://github.com/flathub/flathub/pull/795



